### PR TITLE
Remove unnecessary use of `#[repr(packed)]`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ use std::slice;
 pub mod ffi;
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct RGB8 {
 	r: u8,
 	g: u8,


### PR DESCRIPTION
This struct is laid out the same way with or without `packed`, since
it's just a few bytes.

The removal is good because there's some correctness issues with it, so
there may be breaking changes to it in future and removing it now will
avoid them all together. See
https://github.com/rust-lang/rust/issues/27060.
